### PR TITLE
Fix/handle failed lookup by phone number

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,3 @@ VITE_COGNITO_DOMAIN=https://auth.example.com
 
 ## FAQ/trouble shooting
 
-1. The default prompt asks me for my phone number, but when I tell it a number that doesn't exist in my DynamoDB table, the conversation stops. What should I do?
-
-- It is currently designed to fail in the backend and stop the conversation. Take a look at the ECS logs and see if the tool use is invoked and handle errors that fits your use case.

--- a/backend/nova_s2s_backend.py
+++ b/backend/nova_s2s_backend.py
@@ -345,12 +345,17 @@ class BedrockStreamManager:
                                     else:
                                         content_json_string = str(toolResult)
 
+                                    # check if tool use resulted in an error that needs to be reported to Sonic
+                                    status = 'error' if toolResult.get('status') == 'error' else 'success'
+                                    logger.info(f"Tool result {toolResult} and value of status is {status}")
+
                                     tool_result_event = {
                                         "event": {
                                             "toolResult": {
                                                 "promptName": self.prompt_name,
                                                 "contentName": toolContent,
                                                 "content": content_json_string,
+                                                "status" : status
                                             }
                                         }
                                     }

--- a/backend/retrieve_user_profile.py
+++ b/backend/retrieve_user_profile.py
@@ -28,6 +28,10 @@ logger = logging.getLogger(__name__)
 # Load environment variables from .env file
 load_dotenv()
 
+defaultResponse = {
+    "status": "error",
+    "response": "Sorry we couldn't locate you in our records with phone# {phone_number}. Could you please check your details again?"
+}
 
 def get_dynamodb_table_name():
     """
@@ -75,7 +79,9 @@ def lookup_phone_number(phone_number: str):
             return response["Item"]
         else:
             logger.info(f"No DDB entry found for phone number")
-            return None
+            #set the phone number received for look up and send message back to Sonic that we couldn't locate it in our records. Could you please check your details again?
+            defaultResponse["phone_number"] = phone_number
+            return defaultResponse
 
     except (ProfileNotFound, NoCredentialsError) as e:
         logger.error(f"AWS credential error: {str(e)}")
@@ -94,7 +100,7 @@ def lookup_phone_number(phone_number: str):
         else:
             logger.error(f"DynamoDB ClientError: {error_code} - {error_message}")
             raise RuntimeError(f"DynamoDB error: {error_message}")
-
+    
     except ConnectionError as e:
         logger.error(f"Network error connecting to AWS: {str(e)}")
         raise ConnectionError(f"Network error connecting to AWS: {str(e)}")
@@ -103,7 +109,7 @@ def lookup_phone_number(phone_number: str):
         logger.error(f"Unexpected error querying DynamoDB: {str(e)}")
         raise RuntimeError(f"Error querying DynamoDB: {str(e)}")
 
-
+    
 def main(phone_number: str):
     """
     Main function to process phone number lookup requests.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When lookup by phone number fails to return valid response, it is important to return some message ideally with and status flag set to "error" with a description of the error. This should be sent back to Nova Sonic as part of Tool Result Event message. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
