### PR TITLE
Fix: failing ECS health checks - Specified ARM64 platform flag in ECR asset build configuration

### DIFF
--- a/cdk/lib/s2s-stack.ts
+++ b/cdk/lib/s2s-stack.ts
@@ -16,6 +16,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
+import * as ecr from "aws-cdk-lib/aws-ecr-assets";
 import * as ecs from "aws-cdk-lib/aws-ecs";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as path from "path";
@@ -153,6 +154,7 @@ export class S2SAppStack extends cdk.Stack {
         path.join(__dirname, "../../backend"),
         {
           buildArgs: {},
+          platform: ecr.Platform.LINUX_ARM64,
         }
       ),
       logging: ecs.LogDrivers.awsLogs({ streamPrefix: "websocket" }),


### PR DESCRIPTION
Fixes #10 

## Changes

To fix the issue where the CDK deployment gets stuck on creating the ECS websocket service (as it fails health checks) on x86 based machines, have added the following enhancements:

To the AWS CDK stack configuration for the `S2SAppStack` class. The changes include adding support for building Docker images targeting the ARM64 platform and importing the necessary ECR module to support this functionality.

* [`cdk/lib/s2s-stack.ts`](diffhunk://#diff-c296636a009e594693c61dc54789ae90f58df7d39cd091db2b6cc6b81d71f178R157): Added the `ecr.Platform.LINUX_ARM64` platform specification to the Docker image build configuration, enabling support for ARM64 architecture.

### How the fix resolves the issue

In the CDK stack config, it is explicitly mentioned to use ARM64 as our ECS cluster's machine config.

In the Dockerfile for the `/backend` directory, we are building the image using the `python:3.12` base image. This base image is architecture aware, thus detects what CPU architecture the machine has, the one the image is being built on.

For instance, if we clone this repo on a Mac (ARM64 based) and run `./deploy.sh` - docker will detect the Mac's CPU architecture (i.e ARM64 in this case) and built the image based on that. This image is pushed to ECR and later used in ECS (which was set to use ARM64 architecture).

In my case, I'm on a Dell Latitude laptop (Intel x86_64 based chip). Docker builds an architecture aware (i.e x86_64 based) image on my laptop, pushes it to ECR and then in ECS is where this conflicts as the ECS config is explicitly set to ARM64.

This fix specifies a flag to Docker for building an ARM64 based image when creating this ECR asset.
 