### PR TITLE
temporary fix: Tool use works even 6 hours after deployment (temp credentials expire) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 frontend/dist/**
 cdk.context.json
+.roo
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,macos,visualstudiocode,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,macos,visualstudiocode,node

--- a/backend/nova_s2s_backend.py
+++ b/backend/nova_s2s_backend.py
@@ -85,6 +85,7 @@ class BedrockStreamManager:
     def _initialize_client(self):
         """Initialize the Bedrock client with fresh credentials."""
         # Fetch fresh credentials from ECS container metadata endpoint
+        # The whole task gets restart every 5 hours, but leaving this logic as a backup refresh method: tools will stop working, but Nova Sonic connection will still work.
         try:
             uri = os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
             if uri:
@@ -119,10 +120,10 @@ class BedrockStreamManager:
         self._initialize_client()
 
     async def initialize_stream(self):
+        """Initialize the bidirectional stream with Bedrock."""
 
         self._ensure_fresh_client()
 
-        """Initialize the bidirectional stream with Bedrock."""
         if not self.bedrock_client:
             self._initialize_client()
 
@@ -346,7 +347,11 @@ class BedrockStreamManager:
                                         content_json_string = str(toolResult)
 
                                     # check if tool use resulted in an error that needs to be reported to Sonic
-                                    status = 'error' if toolResult.get('status') == 'error' else 'success'
+                                    status = (
+                                        "error"
+                                        if toolResult.get("status") == "error"
+                                        else "success"
+                                    )
                                     # logger.info(f"Tool result {toolResult} and value of status is {status}")
 
                                     tool_result_event = {
@@ -355,7 +360,7 @@ class BedrockStreamManager:
                                                 "promptName": self.prompt_name,
                                                 "contentName": toolContent,
                                                 "content": content_json_string,
-                                                "status" : status
+                                                "status": status,
                                             }
                                         }
                                     }

--- a/backend/retrieve_user_profile.py
+++ b/backend/retrieve_user_profile.py
@@ -30,8 +30,9 @@ load_dotenv()
 
 defaultResponse = {
     "status": "error",
-    "response": "Sorry we couldn't locate you in our records with phone# {phone_number}. Could you please check your details again?"
+    "response": "Sorry we couldn't locate you in our records with phone# {phone_number}. Could you please check your details again?",
 }
+
 
 def get_dynamodb_table_name():
     """
@@ -79,7 +80,7 @@ def lookup_phone_number(phone_number: str):
             return response["Item"]
         else:
             logger.info(f"No DDB entry found for phone number")
-            #set the phone number received for look up and send message back to Sonic that we couldn't locate it in our records. Could you please check your details again?
+            # set the phone number received for look up and send message back to Sonic that we couldn't locate it in our records. Could you please check your details again?
             defaultResponse["phone_number"] = phone_number
             return defaultResponse
 
@@ -100,7 +101,7 @@ def lookup_phone_number(phone_number: str):
         else:
             logger.error(f"DynamoDB ClientError: {error_code} - {error_message}")
             raise RuntimeError(f"DynamoDB error: {error_message}")
-    
+
     except ConnectionError as e:
         logger.error(f"Network error connecting to AWS: {str(e)}")
         raise ConnectionError(f"Network error connecting to AWS: {str(e)}")
@@ -109,7 +110,7 @@ def lookup_phone_number(phone_number: str):
         logger.error(f"Unexpected error querying DynamoDB: {str(e)}")
         raise RuntimeError(f"Error querying DynamoDB: {str(e)}")
 
-    
+
 def main(phone_number: str):
     """
     Main function to process phone number lookup requests.

--- a/cdk/lambda/ecsTaskRotater/index.ts
+++ b/cdk/lambda/ecsTaskRotater/index.ts
@@ -1,0 +1,65 @@
+const AWS = require("aws-sdk");
+const ecs = new AWS.ECS();
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+exports.handler = async (event: any) => {
+  const cluster = process.env.ECS_CLUSTER_NAME;
+  const service = process.env.ECS_SERVICE_NAME;
+  const delayBetweenStops = 60000; // 60 seconds default
+
+  try {
+    // List running tasks for the service
+    const { taskArns } = await ecs
+      .listTasks({
+        cluster,
+        serviceName: service,
+        desiredStatus: "RUNNING",
+      })
+      .promise();
+
+    let successfulStops = 0;
+    const errors = [];
+    console.log(`Retrieved running tasks: ${taskArns}`);
+
+    // Process tasks sequentially
+    for (const taskArn of taskArns) {
+      try {
+        await ecs
+          .stopTask({
+            cluster,
+            task: taskArn,
+            reason: "Rolling restart one task at a time",
+          })
+          .promise();
+
+        successfulStops++;
+        console.log(`Stopped task ${taskArn}`);
+
+        // Wait for new task to become healthy
+        if (taskArns.length > 1) {
+          await sleep(delayBetweenStops);
+        }
+      } catch (error) {
+        console.error(`Failed to stop ${taskArn}:`, error);
+        errors.push(`${taskArn}: ${error}`);
+      }
+    }
+
+    const resultMessage = `Stopped ${successfulStops}/${taskArns.length} tasks.`;
+    if (errors.length > 0) {
+      return {
+        statusCode: 207, // Multi-status
+        body: JSON.stringify({
+          message: resultMessage,
+          errors,
+        }),
+      };
+    }
+
+    return resultMessage;
+  } catch (error) {
+    console.error("Critical error:", error);
+    throw new Error(`Restart failed: ${error}`);
+  }
+};


### PR DESCRIPTION
*Issue #, if available:* #16 

*Description of changes:*

Added an easy-to-remove Lambda function that stops ECS tasks one by one, letting ECS to start new tasks. This is to force refresh all the credentials for Nova Sonic WebSocket server as well as tool use modules. This change resolves all the issues related to credentials such as #4 #6 #8 #9 #15 #16.

The way temporary credentials are handled force this solution to implement manual credential refresh logic. While this is possible, we find that it introduces more complexity when trying to add new tools. The point of this repository is to easily experiment and extend to whatever use cases people have. Thus, we decided to integrate this rather hacky temporary solution until the experimental Python SDK supports boto-like credential fetching from ECS tasks natively.

While this change minimizes session disruptions by stopping one task at a time, it still drops connections every 5 hours if you happened to have an active session during task rotation. We believe it is an acceptable risk given that this will be used for PoCs and experiments. We plan to remove this Lambda function when we have the official Python SDK for Amazon Nova Sonic gets stabilized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
