### PR TITLE
Improve local development workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 frontend/dist/**
 cdk.context.json
 .roo
+frontend/config.js
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,macos,visualstudiocode,node
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,macos,visualstudiocode,node

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ async def processToolUse(self, toolName, toolUseContent):
 
 ### Local development
 
-Assume credentials for an AWS account with Nova S2S enabled in Amazon Bedrock and export: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
+Assume credentials for an AWS account with Amazon Nova Sonic enabled in Amazon Bedrock and export: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
 
 Run `npm run dev` in the same shell session as above to start frontend and backend containers.
 Both use a file watching mechanism to be notified of local code changes and reload automatically.
@@ -243,6 +243,6 @@ ARG TARGETARCH=arm64
 FROM --platform=$TARGETARCH python:3.12
 ```
 
-2. `npm run dev` hangs and the backend container does not exit
+2. `npm run dev` hangs and the backend container does not exit. I get the error `docker: Error response from daemon: driver failed programming external connectivity on endpoint s2s-backend-dev` when I try to run the command again.
 
-To force the backend container to stop, run `docker rm -f s2s-backend-dev`.
+Run `docker rm -f s2s-backend-dev` to remove the running container image and run `npm run dev` again.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,13 @@ async def processToolUse(self, toolName, toolUseContent):
 
 ### Local development
 
-🚧 Coming soon: we are looking for ways to make development easier by running both frontend and backend locally (See: https://github.com/aws-samples/sample-sonic-cdk-agent/issues/19)
+Assume credentials for an AWS account with Nova S2S enabled in Amazon Bedrock and export: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`.
+
+Run `npm run dev` in the same shell session as above to start frontend and backend containers.
+Both use a file watching mechanism to be notified of local code changes and reload automatically.
+Re-run the `npm` command only if changes are made to the Dockerfile, Python libraries or NPM dependencies that require installation, as these are not picked up by the file watcher.
+
+The frontend is accessible at http://localhost:5173/ and the backend at http://localhost:8080/, with authentication disabled for both.
 
 ## FAQ/trouble shooting
 
@@ -236,3 +242,7 @@ async def processToolUse(self, toolName, toolUseContent):
 ARG TARGETARCH=arm64
 FROM --platform=$TARGETARCH python:3.12
 ```
+
+2. `npm run dev` hangs and the backend container does not exit
+
+To force the backend container to stop, run `docker rm -f s2s-backend-dev`.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.13-alpine
 
 WORKDIR /app
 
@@ -6,8 +6,8 @@ WORKDIR /app
 COPY requirements.txt ./
 
 # Install dependencies
+RUN apk add --update jq curl py-pip inotify-tools
 RUN pip install --no-cache-dir -r requirements.txt
-RUN apt-get update && apt-get install -y jq curl 
 
 # Copy the Python files and .env
 COPY nova_s2s_backend.py knowledge_base_lookup.py retrieve_user_profile.py cognito.py entrypoint.sh .env ./
@@ -19,6 +19,3 @@ ENV LOGLEVEL=INFO
 
 RUN chmod +x entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]
-
-# Command to run the application
-CMD ["python", "nova_s2s_backend.py"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # Copyright 2025 Amazon.com, Inc. and its affiliates. All Rights Reserved.
@@ -15,22 +15,64 @@
 # permissions and limitations under the License.
 #
 
+# Function to check if running in ECS
+is_running_in_ecs() {
+  # Try to access the ECS metadata endpoint with a 1 second timeout
+  if curl -s --connect-timeout 1 http://169.254.170.2 > /dev/null 2>&1; then
+    echo "Running in ECS environment"
+    return 0
+  else
+    echo "Not running in ECS environment"
+    return 1
+  fi
+}
+
 # Function to refresh credentials
 refresh_credentials() {
   # Get credentials from ECS container metadata endpoint
   CREDS=$(curl -s 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
-  
+
   # Extract credentials and set as environment variables
   export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq -r '.AccessKeyId')
   export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq -r '.SecretAccessKey')
   export AWS_SESSION_TOKEN=$(echo $CREDS | jq -r '.Token')
   export AWS_REGION=$(curl -s 169.254.169.254/latest/meta-data/placement/region || echo "us-east-1")
-  
+
   echo "AWS credentials refreshed at $(date)"
 }
 
-# Initial credential fetch
-refresh_credentials
+env
 
-# Execute the main application
-exec "$@"
+# Check if running in ECS and refresh credentials if so
+if is_running_in_ecs; then
+  refresh_credentials
+else
+  echo "Skipping credential refresh - not in ECS environment"
+fi
+
+if [ "$DEV_MODE" = "true" ]; then
+  echo "Running in DEV_MODE with inotifywait..."
+
+  # Start the initial process
+  python nova_s2s_backend.py &
+  PID=$!
+
+  # Monitor directory for changes
+  while true; do
+    inotifywait -r -e modify,create,delete /app --format "%e %w%f"
+    echo "Change detected, restarting process..."
+
+    # Kill the previous process if it exists
+    if [ -n "$PID" ]; then
+      kill $PID 2>/dev/null || true
+      wait $PID 2>/dev/null || true
+    fi
+
+    # Start the process again
+    python nova_s2s_backend.py &
+    PID=$!
+  done
+else
+  echo "Running in normal mode..."
+  exec python nova_s2s_backend.py
+fi

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -29,12 +29,9 @@ let uiInitialized = false; // Track if UI has been initialized
 
 // Initialize on page load
 document.addEventListener("DOMContentLoaded", async () => {
-  // Initialize Cognito authentication first
-  cognitoAuth = getCognitoAuth();
-
-  // Handle authentication before initializing the app
   try {
-    const isAuthenticated = await cognitoAuth.handleAuth();
+    // Attempt authentication
+    const isAuthenticated = await doCognitoAuthentication();
 
     if (isAuthenticated) {
       // Create HTML structure if not already created
@@ -137,6 +134,19 @@ function showSaveConfirmation() {
       saveConfirmationElement.style.display = "none";
     }, 2000);
   }
+}
+
+// Handle authentication process
+async function doCognitoAuthentication() {
+  // Bypass authentication in development mode
+  if (import.meta.env.DEV) {
+    console.log("Running in local development mode, bypassing authentication.");
+    return true;
+  }
+
+  cognitoAuth = getCognitoAuth();
+  const isAuthenticated = await cognitoAuth.handleAuth();
+  return isAuthenticated;
 }
 
 // Logout function
@@ -522,14 +532,14 @@ function createHtmlStructure() {
           </div>
         </div>
       </div>
-      
+
       <!-- System Prompt Editor (initially hidden) -->
       <div id="system-prompt-container" style="display: none;">
         <h2>System Prompt Editor</h2>
         <div id="save-confirmation" style="display: none;">Saved!</div>
         <div class="editor-container">
-          <textarea 
-            id="system-prompt-textarea" 
+          <textarea
+            id="system-prompt-textarea"
             class="system-prompt-textarea"
             placeholder="Enter system prompt here..."
           ></textarea>
@@ -538,13 +548,13 @@ function createHtmlStructure() {
           </div>
         </div>
       </div>
-      
+
       <div id="chat-container"></div>
-      
+
       <div id="controls">
         <!-- Controls moved to header area -->
       </div>
-      
+
       <div class="footer">
         <div>Voice Chat Interface v1.0</div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "frontend",
         "cdk"
       ],
-      "devDependencies": {}
+      "devDependencies": {
+        "concurrently": "^8.2.2"
+      }
     },
     "cdk": {
       "version": "0.1.0",
@@ -1288,6 +1290,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4243,6 +4257,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
+      "integrity": "sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "date-fns": "^2.30.0",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "spawn-command": "0.0.2",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": "^14.13.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/constructs": {
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
@@ -4298,6 +4354,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -6001,6 +6073,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6486,6 +6564,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6590,6 +6674,15 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
@@ -6663,6 +6756,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6717,6 +6822,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/spawn-command": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
+      "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -6929,6 +7040,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "description": "A package which deploys speech-to-speech utilities to AWS using CDK.",
   "scripts": {
-    "dev": "cd frontend && npm run dev",
+    "generate-config": "echo \"window.APP_CONFIG = { cognitoUserPoolId: '', cognitoAppClientId: '', backendEndpoint: 'http://localhost:8080/', appUrl: 'http://localhost:5173/', cognitoDomain: '' };\" > frontend/config.js",
+    "dev": "npm run generate-config && concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
+    "dev:frontend": "cd frontend && npm run dev",
+    "dev:backend": "cd backend && docker build -t s2s-backend-dev . && docker run --name s2s-backend-dev --rm -p 8080:80 --volume ./:/app -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} -e AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN} -e DEV_MODE=true s2s-backend-dev",
     "build": "npm run build:frontend && npm run build:cdk",
     "build:frontend": "cd frontend && npx vite build",
     "cdk:build": "npm run build:frontend && cd cdk && npm run build",
@@ -15,5 +18,7 @@
     "frontend",
     "cdk"
   ],
-  "devDependencies": {}
+  "devDependencies": {
+    "concurrently": "^8.2.2"
+  }
 }


### PR DESCRIPTION
Updated `npm run dev` to build and start both backend and frontend, while bypassing Cognito authentication.

Both Vite and the Python backend will restart/reload on file changes made to the local code.

For AWS authentication, local AWS credential environment variables are used to calling of Nova S2S.

Other changes
- switch to a smaller base Docker image, reducing container size from 1.2GB to 200MB

*Issue #, if available:* #19 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
